### PR TITLE
Show trailer whitespaces at startup

### DIFF
--- a/plugin/trailertrash.vim
+++ b/plugin/trailertrash.vim
@@ -73,7 +73,6 @@ call ShowTrailerTrash()
 "nmap <silent> <Leader>s :call ShowTrailerTrash()<CR>
 
 " Matches
-hi UnwantedTrailerTrash guifg=NONE guibg=NONE gui=NONE ctermfg=NONE ctermbg=NONE cterm=NONE
 au BufEnter    * call s:TrailerMatch('/\s\+$/')
 au InsertEnter * call s:TrailerMatch('/\s\+\%#\@<!$/')
 au InsertLeave * call s:TrailerMatch('/\s\+$/')


### PR DESCRIPTION
Trailer whitespaces are not shown at startup after introduced ShowTrailerTrash().
Now I can see trailer whitespaces after executing Trailer command twice.
