### PR TITLE
escape bracket

### DIFF
--- a/plugin/trailertrash.vim
+++ b/plugin/trailertrash.vim
@@ -37,7 +37,7 @@ command! -bar -range=% Trim :call KillTrailerTrash(<line1>,<line2>)
 " User can override blacklist. This match as regexp pattern.
 let s:blacklist = get(g:, 'trailertrash_blacklist', [
 \ '__Calendar',
-\ '[unite]',
+\ '\[unite\]',
 \])
 
 function! s:TrailerMatch(pattern)


### PR DESCRIPTION
Since af94f3b76bc912c5aac125c7ff2e4ffb0b2ead56,  trailertrash.vim ignores not only unite buffers but also all buffers contain `u`, `n`, `i`, `t` or `e` letter. This pull request solve this problem.
