### PR TITLE
Add buffer var to disable displaying trailing spaces

### DIFF
--- a/plugin/trailertrash.vim
+++ b/plugin/trailertrash.vim
@@ -48,7 +48,7 @@ function! s:TrailerMatch(pattern)
                 return
             endif
         endfor
-        if (exists("b:show_trailertrash") && b:show_trailertrash == 0)
+        if (exists("b:disable_trailertrash") && b:disable_trailertrash)
             return
         endif
         exe "match" "UnwantedTrailerTrash" a:pattern


### PR DESCRIPTION
When using Unite's `unite_settings` the show setting didn't work every time, by inverting this to a disable setting it works. To make trailer trash play nice with unite you can put the following in your vimrc:

```
function! s:unite_settings()
  let b:disable_trailertrash=1
endfunction
```
